### PR TITLE
Add NVMe support for Plextor/LiteOn/Hynix

### DIFF
--- a/CLOVER/config.plist
+++ b/CLOVER/config.plist
@@ -493,6 +493,16 @@
 		</array>
 		<key>KextsToPatch</key>
 		<array>
+      <dict>
+				<key>Comment</key>
+				<string>IONVMeFamily: Ignore FLBAS bit:4 being set - for Plextor/LiteOn/Hynix (credit Pene)</string>
+				<key>Name</key>
+				<string>com.apple.iokit.IONVMeFamily</string>
+				<key>Find</key>
+				<data>ikga9sEQ</data>
+				<key>Replace</key>
+				<data>ikga9sEA</data>
+			</dict>
 			<dict>
 				<key>Comment</key>
 				<string>USB Port limit patch 10.14</string>


### PR DESCRIPTION
Please refer to
https://www.insanelymac.com/forum/topic/312803-patch-for-using-nvme-under-macos-sierra-is-ready/?do=findComment&comment=2617639